### PR TITLE
Adjust baseURL - closes #17

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://philotfarnsworth.github.io/APrettyHuGoinWebsite'
+baseURL = 'https://philotfarnsworth.github.io/APrettyHuGoinWebsite/'
 languageCode = 'en-us'
 enableRobotsTXT = 'true'
 title = "A Pretty HuGOin' Website"


### PR DESCRIPTION
## Changes

- Adjust `baseURL` attribute in `config.toml` to include a forward slash at the end of URL.