### PR TITLE
Contents fix

### DIFF
--- a/layouts/partials/listFooter.html
+++ b/layouts/partials/listFooter.html
@@ -1,5 +1,5 @@
 <footer>
     <nav>
-        <a href="{{.Site.BaseURL}}{{.Section}}/index" title="Foreword">Start Reading</a>
+        <a href="{{.Site.BaseURL}}{{.Section}}/index/" title="Foreword">Start Reading</a>
     </nav>
 </footer>


### PR DESCRIPTION
This PR closes #20.  Added a forward slash to the end of URL in static 'Contents' leading to 'Foreword' page.

## Comments
This bug was a little annoying, as I had thought it would've been covered under our static navigation testing, but due to how routing and URLs resolve on a Github Pages build versus the test server, `Diatribes/index` and `Diatribes/index/` resolve to 'Contents' and 'Foreword' respectively.  While the test server helpfully adds a forward slash on the end of the URL, our Github version does not.  This issue bears some closer scrutiny in future sites built with Hugo, possibly with better organization on my part.  

For the time being, we'll just take care to ensure our URLs are properly formatted, which beyond our two launch bugs, they appear to be.